### PR TITLE
Allow configuration of direct interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,25 @@ Role Variables
 
     - `interfaces`: a list of network interfaces to attach to the VM.
       Each network interface is defined with the following dict:
-        - `network`: Name of the network to which an interface should be attached.
+
+        - `type`: The type of the interface. Possible values:
+
+            - `network`: Attaches the interface to a named Libvirt virtual
+              network. This is the default value.
+            - `direct`: Directly attaches the interface to one of the host's
+              physical interfaces, using the `macvtap` driver.
+        - `network`: Name of the network to which an interface should be
+          attached. Must be specified if and only if the interface `type` is
+          `network`.
+        - `source`: A dict defining the host interface to which this
+          VM interface should be attached. Must be specified if and only if the
+          interface `type` is `direct`. Includes the following attributes:
+
+            - `dev`: The name of the host interface to which this VM interface
+              should be attached.
+            - `mode`: options include `vepa`, `bridge`, `private` and
+              `passthrough`. See `man virsh` for more details. Default is
+              `vepa`.
 
     - `console_log_enabled`: if `true`, log console output to a file at the
       path specified by `console_log_path`, **instead of** to a PTY. If

--- a/tasks/check-interface.yml
+++ b/tasks/check-interface.yml
@@ -1,0 +1,21 @@
+---
+- name: Check network interface has a network name
+  fail:
+    msg: >
+      The interface definition {{ interface }} has type 'network', but does not have
+      a network name defined.
+  when:
+    - interface.type is not defined or
+      interface.type == 'network'
+    - interface.network is not defined
+
+- name: Check direct interface has an interface device name
+  fail:
+    msg: >
+      The interface definition {{ interface }} has type 'direct', but does not have
+      a host source device defined.
+  when:
+    - interface.type is defined
+    - interface.type == 'direct'
+    - interface.source is not defined or
+      interface.source.dev is not defined

--- a/tasks/vm.yml
+++ b/tasks/vm.yml
@@ -10,6 +10,12 @@
   when: console_log_enabled | bool
   become: true
 
+- name: Validate VM interfaces
+  include_tasks: check-interface.yml
+  vars:
+    interface: "{{ item }}"
+  with_items: "{{ vm.interfaces }}"
+
 - name: Ensure the VM is defined
   virt:
     name: "{{ vm.name }}"

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -26,8 +26,13 @@
     </disk>
 {% endfor %}
 {% for interface in interfaces %}
+{% if interface.type is defined and interface.type == 'direct' %}
+    <interface type='direct'>
+      <source dev='{{ interface.source.dev }}' mode='{{ interface.source.mode | default('vepa') }}'/>
+{% else %}
     <interface type='network'>
       <source network='{{ interface.network }}'/>
+{% endif %}
       <model type='virtio'/>
     </interface>
 {% endfor %}


### PR DESCRIPTION
Break out VM interface configuration into direct and virtual-network
types, to allow direct connection to host interfaces as well as to
Libvirt networks.