### PR TITLE
Support Debian based GNU/Linux distributions

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,12 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
   galaxy_tags:
     - cloud
     - kvm

--- a/tasks/vm.yml
+++ b/tasks/vm.yml
@@ -1,10 +1,20 @@
 ---
+- name: Gather os specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+        - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+      skip: true
+  tags: vars
+
 - name: Ensure the VM console log directory exists
   file:
     path: "{{ console_log_path | dirname }}"
     state: directory
-    owner: qemu
-    group: qemu
+    owner: "{{ libvirt_vm_log_owner }}"
+    group: "{{ libvirt_vm_log_owner }}"
     recurse: true
     mode: 0770
   when: console_log_enabled | bool

--- a/tasks/volumes.yml
+++ b/tasks/volumes.yml
@@ -1,4 +1,13 @@
 ---
+- name: Gather os specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+        - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+  tags: vars
+
 - name: Ensure remote images are downloaded
   get_url:
     url: "{{ item }}"
@@ -24,6 +33,7 @@
     {{ libvirt_vm_image_cache_path }}/{{ item.image | basename }}
     {% endif %}
   with_items: "{{ volumes }}"
+  environment: "{{ libvirt_vm_volume_creation_env }}"
   register: volume_result
   changed_when:
     - volume_result is success

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,7 @@
+---
+
+# Who owns the serial console logs in console_log_path
+libvirt_vm_log_owner: libvirt-qemu
+
+# The environment passed to virt_volume.sh
+libvirt_vm_volume_creation_env: {}

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,9 @@
+---
+
+# Who owns the serial console logs in console_log_path
+libvirt_vm_log_owner: qemu
+
+# The environment passed to virt_volume.sh
+libvirt_vm_volume_creation_env:
+  VOLUME_GROUP: qemu
+  VOLUME_OWNER: qemu


### PR DESCRIPTION
- The user `qemu` does not exist on Debian based
  distributions
- libvirt-qemu runs with root permissions so we
  do not need to change the ownership of the volumes
  in the storage pool