### PR TITLE
Default to software emulation if target architecture != host_architecture

### DIFF
--- a/tasks/autodetect.yml
+++ b/tasks/autodetect.yml
@@ -14,7 +14,18 @@
 
     - name: Set a fact containing the virtualisation engine
       set_fact:
-        libvirt_vm_engine: "{% if stat_kvm.stat.exists %}kvm{% else %}qemu{% endif %}"
+        libvirt_vm_engine: >-
+          {%- if ansible_architecture != libvirt_vm_arch -%}
+          {# Virtualisation instructions are generally available only for the host
+          architecture. Ideally we would test for virtualisation instructions, eg. vt-d
+          as it is possible that another architecture could support these even
+          if the emulated cpu architecture is not the same. #}
+          qemu
+          {%- elif stat_kvm.stat.exists -%}
+          kvm
+          {%- else -%}
+          qemu
+          {%- endif -%}
   when: libvirt_vm_engine is none
 
 - name: Detect the virtualisation emulator


### PR DESCRIPTION
The qemu-kvm binary only supports the host architecture. We must
therefore use the qemu-system-<architecture> binaries when the target
architecture is not the same as the host architecture.

Although it may be possible that the host CPU may support acceleration
for a foreign architecture, I do not currently know of any chips that
support this functionality. For this reason, we default to software
emulation.