### PR TITLE
Always undefine a VM before defining it

### DIFF
--- a/tasks/vm.yml
+++ b/tasks/vm.yml
@@ -26,6 +26,19 @@
     interface: "{{ item }}"
   with_items: "{{ interfaces }}"
 
+- name: Undefine libvirt machine if already defined
+  # Otherwise vm.xml.j2 will not be updated when variables are changed
+  #
+  # note(wszumski): the virt module does not seem to support
+  # removing vms with nvram defined - as a workaround, use the
+  # virsh cli directly. It may be better to detect if dumpxml
+  # actually contains an nvram element rather than relying on
+  # boot_firmware having the correct value.
+  command: virsh -c qemu:///system undefine{% if boot_firmware == 'efi' %} --nvram{% endif %} {{ vm.name }}
+  become: true
+  register: result
+  failed_when: result.rc != 0 and "no domain with matching name" not in result.stderr
+
 - name: Ensure the VM is defined
   virt:
     name: "{{ vm.name }}"


### PR DESCRIPTION
It seems that the virt module does not take into account changes to
the templated vm.xml.j2 file. As such, changes to variables used
within this template are not propagated to libvirt i.e the output of
virsh dumpxml remains the same before and after the application of
define.