### PR TITLE
Fix name of libvirt_vm_image_cache_path variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Role Variables
   VM console logs, if a VM-specific log file path is not given. Default is
   "/var/log/libvirt/qemu/".
 
-- `libvirt_image_cache_path`: The directory in which to cache downloaded
+- `libvirt_vm_image_cache_path`: The directory in which to cache downloaded
   images. Default is "/tmp/".
 
 - `libvirt_vm_engine`: virtualisation engine. If not set, the role will attempt

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,11 @@ libvirt_volume_default_format: qcow2
 libvirt_volume_default_device: disk
 
 # Path to cache downloaded images.
+libvirt_vm_image_cache_path: "{{ libvirt_image_cache_path }}"
+
+# NOTE(mgoddard): Temporarily support this name in addition to
+# 'libvirt_vm_image_cache_path'.
+# TODO(mgoddard): Remove this for the next major release.
 libvirt_image_cache_path: "/tmp/"
 
 # CPU architecture.


### PR DESCRIPTION
This was renamed to libvirt_image_cache_path in the defaults and README,
but the name referenced in the task files was still
libvirt_vm_image_cache_path. This change reverts to the original name,
libvirt_vm_image_cache_path.

Temporarily support the use of libvirt_image_cache_path until the next
major release.