### PR TITLE
Custom xml domain definition file and disk device start at vda

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Role Variables
 
 - `libvirt_vm_arch`: CPU architecture, default is `x86_64`.
 
-- `libvirt_vm_uri`: Override the libvirt connection URI. See the 
+- `libvirt_vm_uri`: Override the libvirt connection URI. See the
   [libvirt docs](https://libvirt.org/remote.html) docs for more details.
 
 - `libvirt_vm_virsh_default_env`: Variables contained within this dictionary are
@@ -100,6 +100,7 @@ Role Variables
     - `autostart`: Whether to start the VM when the host starts up. Default is
       `true`.
 
+    - `xml_template`: Optionally supply a modified XML template. Base customisation off the default `vm.xml.j2` template so as to include the expected jinja expressions the role uses.
 
 N.B. the following variables are deprecated: `libvirt_vm_state`,
 `libvirt_vm_name`, `libvirt_vm_memory_mb`, `libvirt_vm_vcpus`,

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,10 +61,13 @@ libvirt_vms:
       # Path to console log file.
       console_log_path: "{{ libvirt_vm_console_log_path }}"
 
+      # XML template file to source domain definition
+      xml_file: vm.xml.j2
+      
 # Variables to add to the enviroment that is used to execute virsh commands
 libvirt_vm_virsh_default_env: "{{  { 'LIBVIRT_DEFAULT_URI': libvirt_vm_uri } if libvirt_vm_uri else {} }}"
 
-# Override for the libvirt connection uri. Leave unset to use the default. 
+# Override for the libvirt connection uri. Leave unset to use the default.
 libvirt_vm_uri: ""
 
 ### DEPRECATED ###

--- a/tasks/vm.yml
+++ b/tasks/vm.yml
@@ -20,7 +20,7 @@
   virt:
     name: "{{ vm.name }}"
     command: define
-    xml: "{{ lookup('template', vm.xml_file) }}"
+    xml: "{{ lookup('template', vm.xml_file | default('vm.xml.j2')) }}"
     uri: "{{ libvirt_vm_uri | default(omit, true) }}"
   become: true
 

--- a/tasks/vm.yml
+++ b/tasks/vm.yml
@@ -20,7 +20,7 @@
   virt:
     name: "{{ vm.name }}"
     command: define
-    xml: "{{ lookup('template', 'vm.xml.j2') }}"
+    xml: "{{ lookup('template', vm.xml_file) }}"
     uri: "{{ libvirt_vm_uri | default(omit, true) }}"
   become: true
 

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -22,7 +22,7 @@
     <disk type='volume' device='{{ volume.device | default(libvirt_volume_default_device) }}'>
       <driver name='qemu' type='{{ volume.format | default(libvirt_volume_default_format) }}'/>
       <source pool='{{ volume.pool }}' volume='{{ volume.name }}'/>
-      <target dev='vd{{ 'abcdefghijklmnopqrstuvwxyz'[loop.index] }}'/>
+      <target dev='vd{{ 'abcdefghijklmnopqrstuvwxyz'[loop.index - 1] }}'/>
     </disk>
 {% endfor %}
 {% for interface in interfaces %}


### PR DESCRIPTION
As per commit comments.

I found it a bit awkward trying to supply / set `vm.xml.j2` as a default in `defaults/main.yml`. When the role runs, if the calling play doesn't set `xml_file`, the role appears to have `vm.xml_file` undefined and the value in  `defaults/main.yml` doesn't have any effect - so duplicating it there is for cosmetic/documentation value. Couldn't think of a cleaner way about it given the defaults are a singleton and omitted parts don't seem to set defaults.

Tested both setting xml_file and not setting xml_file as working while my custom file `el7_vm.xml.j2` was in the playbook dir `/templates` location.

E.g.

```
         libvirt_vms:
            - state: present
              xml_file: el7_vm.xml.j2
              name: test
              memory_mb: 16384
              vcpus: 4
              volumes:
                - name: test-hostvg
                  device: disk
                  format: qcow2
                  capacity: 512GB
                  backing_image: rhel_backing_image.qcow2
                  pool: default
                - name: test-vg_data_hdd
                  device: disk
                  # Note logical volume format for qemu driver is "raw"
                  format: raw
                  capacity: 5TB
                  pool: hdd
              interfaces:
                - type: bridge
                  network: uat
```