### PR TITLE
Allow cpu_mode to be set to none

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Role Variables
 - `libvirt_vm_emulator`: path to emulator binary. If not set, the role will
   attempt to auto-detect the correct emulator to use.
 
+- `libvirt_cpu_mode_default`: The default CPU mode if `libvirt_cpu_mode` or
+  `vm.cpu_mode` is undefined.
+
 - `libvirt_vm_arch`: CPU architecture, default is `x86_64`.
 
 - `libvirt_vm_uri`: Override the libvirt connection URI. See the
@@ -49,7 +52,8 @@ Role Variables
       `libvirt_vm_engine` is `kvm`, otherwise `pc-1.0`.
 
     - `cpu_mode`: Virtual machine CPU mode. Default is `host-passthrough` if
-      `libvirt_vm_engine` is `kvm`, otherwise `host-model`.
+      `libvirt_vm_engine` is `kvm`, otherwise `host-model`. Can be set to none
+      to not configure a cpu mode.
 
     - `volumes`: a list of volumes to attach to the VM.  Each volume is
       defined with the following dict:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,7 +50,7 @@ libvirt_vms:
       machine: "{{ libvirt_vm_machine }}"
 
       # Virtual machine CPU mode.
-      cpu_mode: "{{ libvirt_vm_cpu_mode }}"
+      cpu_mode: "{{ libvirt_vm_cpu_mode | default(libvirt_cpu_mode_default, true) }}"
 
       # List of volumes.
       volumes: "{{ libvirt_vm_volumes }}"
@@ -69,6 +69,9 @@ libvirt_vm_virsh_default_env: "{{  { 'LIBVIRT_DEFAULT_URI': libvirt_vm_uri } if 
 
 # Override for the libvirt connection uri. Leave unset to use the default.
 libvirt_vm_uri: ""
+
+# Default CPU mode if libvirt_vm_cpu_mode or vm.cpu_mode is undefined
+libvirt_cpu_mode_default: "{{ 'host-passthrough' if libvirt_vm_engine == 'kvm' else 'host-model' }}"
 
 ### DEPRECATED ###
 # Use the above settings for each item within `libvirt_vms`, instead of the

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,8 +31,7 @@
          default(libvirt_vm_default_console_log_dir + '/' +  vm.name + '-console.log', true) }}
     machine_default: "{{ none if libvirt_vm_engine == 'kvm' else 'pc-1.0' }}"
     machine: "{{ vm.machine | default(machine_default, true) }}"
-    cpu_mode_default: "{{ 'host-passthrough' if libvirt_vm_engine == 'kvm' else 'host-model' }}"
-    cpu_mode: "{{ vm.cpu_mode | default(cpu_mode_default, true) }}"
+    cpu_mode: "{{ vm.cpu_mode | default(libvirt_cpu_mode_default) }}"
     volumes: "{{ vm.volumes | default([], true) }}"
     interfaces: "{{ vm.interfaces | default([], true) }}"
     start: "{{ vm.start | default(true) }}"

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -13,9 +13,11 @@
     <boot dev='network'/>
     <bios useserial='yes'/>
   </os>
-  <cpu{% if cpu_mode is not none %} mode='{{ cpu_mode }}'{% endif %}>
+  {% if cpu_mode %}
+  <cpu mode='{{ cpu_mode }}'>
     <model fallback='allow'/>
   </cpu>
+  {% endif %}
   <devices>
     <emulator>{{ libvirt_vm_emulator }}</emulator>
 {% for volume in volumes %}


### PR DESCRIPTION
It may be desirable to omit the cpu mode altogether. For instance if there is an emulation bug in one of the cpu features. The previous default of host-model causes all compatible CPU features to be enabled.