### PR TITLE
Mention dependency on qemu-img

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ these deprecated variables.
 Dependencies
 ------------
 
-None
+If using qcow2 format drives qemu-img (in qemu-utils package) is required.
+
 
 Example Playbook
 ----------------


### PR DESCRIPTION
qemu-img is required to create qcow formatted disk images; by
default only raw is available.