### PR TITLE
Fix ansible warning

### DIFF
--- a/tasks/volumes.yml
+++ b/tasks/volumes.yml
@@ -26,7 +26,7 @@
     -b {{ item.backing_image }}
     {% endif %}
   with_items: "{{ volumes }}"
-  when: "{{ item.device | default(libvirt_volume_default_device) == 'disk' }}"
+  when: item.device | default(libvirt_volume_default_device) == 'disk'
   environment: "{{ libvirt_vm_script_env }}"
   register: volume_result
   changed_when:


### PR DESCRIPTION
TASK [stackhpc.libvirt-vm : Ensure the VM volumes exist] ***********
[WARNING]: conditional statements should not include jinja2
templating delimiters such as {{ }} or {% %}. Found:
{{ item.device | default(libvirt_volume_default_device) == 'disk' }}