### PR TITLE
Allow to manually set volume target, thereby influence bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Role Variables
         - `image`: (optional) a URL to an image with which the volume is initalised (full copy).
         - `backing_image`: (optional) name of the backing volume which is assumed to already be the same pool (copy-on-write).
         - `image` and `backing_image` are mutually exclusive options.
+        - `target`: (optional) Manually influence type and order of volumes
 
     - `interfaces`: a list of network interfaces to attach to the VM.
       Each network interface is defined with the following dict:
@@ -161,6 +162,11 @@ Example Playbook
                   format: 'qcow2'
                   capacity: '400GB'
                   pool: 'my-pool'
+                - name: 'debian-10.2.0-amd64-netinst.iso'
+                  type: 'file'
+                  device: 'cdrom'
+                  format: 'raw'
+                  target: 'hda'  # first device on ide bus
               interfaces:
                 - network: 'br-datacentre'
 

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -38,7 +38,11 @@
       {% else %}
       <source pool='{{ volume.pool }}' volume='{{ volume.name }}'/>
       {% endif %}
+      {% if volume.target is undefined %}
       <target dev='vd{{ 'abcdefghijklmnopqrstuvwxyz'[loop.index - 1] }}'/>
+      {% else %}
+      <target dev={{ volume.target }} />
+      {% endif %}
     </disk>
 {% endfor %}
 {% for interface in interfaces %}


### PR DESCRIPTION
The optional bus attribute specifies the type of disk device to emulate;
possible values are driver specific, with typical values being "ide", "scsi",
"virtio", "xen", "usb", "sata", or "sd" "sd" since 1.1.2. If omitted, the bus
type is inferred from the style of the device name (e.g. a device named 'sda'
will typically be exported using a SCSI bus).
https://libvirt.org/formatdomain.html#elementsDisks