### PR TITLE
Give the VM a rng device by default to avoid entropy starvation

### DIFF
--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -86,5 +86,6 @@
       <listen type='address' address='127.0.0.1'/>
     </graphics>
 {% endif %}
+    <rng model="virtio"><backend model="random">/dev/urandom</backend></rng>
   </devices>
 </domain>


### PR DESCRIPTION
/dev/urandom recommended by libvirt
https://libvirt.org/formatdomain.html#elementsRng