### PR TITLE
Archlinux support, libvirt zfs pool support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,13 @@ Role Variables
       defined with the following dict:
         - `pool`: Name or UUID of the storage pool from which the volume should be
           allocated.
+        - `zfs_pool`: Set this option to `True`, if your pool is based on zfs (`pool type="zfs"` in your libvirt host setup). Only works with `disk` type volumes. A fact set by role `stackhpc.libvirt-host` is required.
         - `name`: Name to associate with the volume being created; For `file` type volumes include extension if you would like volumes created with one.
         - `file_path`: Where the image of `file` type volumes should be placed; defaults to `libvirt_volume_default_images_path`
         - `device`: `disk` or `cdrom`
         - `capacity`: volume capacity (can be suffixed with M,G,T or MB,GB,TB, etc) (required when type is `disk`)
         - `format`: options include `raw`, `qcow2`, `vmdk`.  See `man virsh` for the
-          full range.  Default is `qcow2`
+          full range.  Default is `qcow2`.
         - `image`: (optional) a URL to an image with which the volume is initalised (full copy).
         - `backing_image`: (optional) name of the backing volume which is assumed to already be the same pool (copy-on-write).
         - `image` and `backing_image` are mutually exclusive options.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ Role Variables
       defined with the following dict:
         - `pool`: Name or UUID of the storage pool from which the volume should be
           allocated.
-        - `zfs_pool`: Set this option to `True`, if your pool is based on zfs (`pool type="zfs"` in your libvirt host setup). Only works with `disk` type volumes. A fact set by role `stackhpc.libvirt-host` is required.
         - `name`: Name to associate with the volume being created; For `file` type volumes include extension if you would like volumes created with one.
         - `file_path`: Where the image of `file` type volumes should be placed; defaults to `libvirt_volume_default_images_path`
         - `device`: `disk` or `cdrom`

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,9 @@ galaxy_info:
     - name: Debian
       versions:
         - all
+    - name: ArchLinux
+      versions:
+        - all
   galaxy_tags:
     - cloud
     - kvm

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -41,9 +41,9 @@
       <source pool='{{ volume.pool }}' volume='{{ volume.name }}'/>
       {% endif %}
       {% if volume.target is undefined %}
-      <target dev='vd{{ 'abcdefghijklmnopqrstuvwxyz'[loop.index - 1] }} {% if volume.device | default(libvirt_volume_default_device) == 'cdrom' %}}bus='sata'{{% endif %}}'/>
+      <target dev='vd{{ 'abcdefghijklmnopqrstuvwxyz'[loop.index - 1] }} {% if volume.device | default(libvirt_volume_default_device) == 'cdrom' %}bus='sata'{% endif %}'/>
       {% else %}
-      <target dev='{{ volume.target }}' {% if volume.device | default(libvirt_volume_default_device) == 'cdrom' %}}bus='sata'{{% endif %}}/>
+      <target dev='{{ volume.target }}' {% if volume.device | default(libvirt_volume_default_device) == 'cdrom' %}bus='sata'{% endif %}/>
       {% endif %}
     </disk>
 {% endfor %}

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -41,9 +41,9 @@
       <source pool='{{ volume.pool }}' volume='{{ volume.name }}'/>
       {% endif %}
       {% if volume.target is undefined %}
-      <target dev='vd{{ 'abcdefghijklmnopqrstuvwxyz'[loop.index - 1] }}'/>
+      <target dev='vd{{ 'abcdefghijklmnopqrstuvwxyz'[loop.index - 1] }} {% if volume.device | default(libvirt_volume_default_device) == 'cdrom' %}}bus='sata'{{% endif %}}'/>
       {% else %}
-      <target dev='{{ volume.target }}' />
+      <target dev='{{ volume.target }}' {% if volume.device | default(libvirt_volume_default_device) == 'cdrom' %}}bus='sata'{{% endif %}}/>
       {% endif %}
     </disk>
 {% endfor %}

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -39,7 +39,7 @@
       <source pool='{{ volume.pool }}' volume='{{ volume.name }}'/>
       {% endif %}
       {% if volume.target is undefined %}
-      <target dev='vd{{ 'abcdefghijklmnopqrstuvwxyz'[loop.index - 1] }}' {% if volume.device | default(libvirt_volume_default_device) == 'cdrom' %}bus='sata'{% else %}bus='virtio'{% endif %}/>
+      <target dev='vd{{ 'abcdefghijklmnopqrstuvwxyz'[loop.index - 1] }}' {% if volume.device | default(libvirt_volume_default_device) == 'cdrom' %}bus='sata'{% endif %}/>
       {% else %}
       <target dev='{{ volume.target }}' {% if volume.device | default(libvirt_volume_default_device) == 'cdrom' %}bus='sata'{% endif %}/>
       {% endif %}

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -35,6 +35,8 @@
       <driver name='qemu' type='{{ volume.format | default(libvirt_volume_default_format) }}'/>
       {% if volume.type | default(libvirt_volume_default_type) == 'file' %}
       <source file='{{ volume.file_path |default(libvirt_volume_default_images_path) }}/{{ volume.name}}'/>
+      {% elif volume.zfs_pool is defined and volume.zfs_pool is sameas true %}
+      <source dev='/dev/zvol/{{ ansible_local.libvirt.zfs_storage_pools[volume.pool] }}/{{ volume.name }}'/>
       {% else %}
       <source pool='{{ volume.pool }}' volume='{{ volume.name }}'/>
       {% endif %}

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -41,7 +41,7 @@
       <source pool='{{ volume.pool }}' volume='{{ volume.name }}'/>
       {% endif %}
       {% if volume.target is undefined %}
-      <target dev='vd{{ 'abcdefghijklmnopqrstuvwxyz'[loop.index - 1] }} {% if volume.device | default(libvirt_volume_default_device) == 'cdrom' %}bus='sata'{% endif %}'/>
+      <target dev='vd{{ 'abcdefghijklmnopqrstuvwxyz'[loop.index - 1] }}' {% if volume.device | default(libvirt_volume_default_device) == 'cdrom' %}bus='sata'{% endif %}/>
       {% else %}
       <target dev='{{ volume.target }}' {% if volume.device | default(libvirt_volume_default_device) == 'cdrom' %}bus='sata'{% endif %}/>
       {% endif %}

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -35,13 +35,11 @@
       <driver name='qemu' type='{{ volume.format | default(libvirt_volume_default_format) }}'/>
       {% if volume.type | default(libvirt_volume_default_type) == 'file' %}
       <source file='{{ volume.file_path |default(libvirt_volume_default_images_path) }}/{{ volume.name}}'/>
-      {% elif volume.zfs_pool is defined and volume.zfs_pool is sameas true %}
-      <source dev='/dev/zvol/{{ ansible_local.libvirt.zfs_storage_pools[volume.pool] }}/{{ volume.name }}'/>
       {% else %}
       <source pool='{{ volume.pool }}' volume='{{ volume.name }}'/>
       {% endif %}
       {% if volume.target is undefined %}
-      <target dev='vd{{ 'abcdefghijklmnopqrstuvwxyz'[loop.index - 1] }}' {% if volume.device | default(libvirt_volume_default_device) == 'cdrom' %}bus='sata'{% endif %}/>
+      <target dev='vd{{ 'abcdefghijklmnopqrstuvwxyz'[loop.index - 1] }}' {% if volume.device | default(libvirt_volume_default_device) == 'cdrom' %}bus='sata'{% else %}bus='virtio'{% endif %}/>
       {% else %}
       <target dev='{{ volume.target }}' {% if volume.device | default(libvirt_volume_default_device) == 'cdrom' %}bus='sata'{% endif %}/>
       {% endif %}

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,12 +1,9 @@
 ---
-
 # Who owns the serial console logs in console_log_path
 libvirt_vm_log_owner: root
 
 # The environment passed to virt_volume.sh
-libvirt_vm_script_env_arch: []
-# VOLUME_GROUP: qemu
-# VOLUME_OWNER: qemu
+libvirt_vm_script_env_arch: {}
 
 libvirt_vm_script_env: >-
   {{ libvirt_vm_script_env_arch | combine(libvirt_vm_virsh_default_env) }}

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,0 +1,15 @@
+---
+
+# Who owns the serial console logs in console_log_path
+libvirt_vm_log_owner: root
+
+# The environment passed to virt_volume.sh
+libvirt_vm_script_env_arch: []
+# VOLUME_GROUP: qemu
+# VOLUME_OWNER: qemu
+
+libvirt_vm_script_env: >-
+  {{ libvirt_vm_script_env_arch | combine(libvirt_vm_virsh_default_env) }}
+
+# Archlinux qemu comes with kvm support compiled in
+libvirt_vm_emulator: /usr/bin/qemu-system-x86_64


### PR DESCRIPTION
This PR adds support to create VMs on an Archlinux host and optionally allows use of zfs backed storage pool in libvirt. Requires https://github.com/stackhpc/ansible-role-libvirt-host/pull/23 to be merged first.