### PR TITLE
Create volume when type is volume, not device is disk

### DIFF
--- a/tasks/volumes.yml
+++ b/tasks/volumes.yml
@@ -27,7 +27,7 @@
     {% endif %}
     -a {{ ansible_check_mode }}
   with_items: "{{ volumes }}"
-  when: item.device | default(libvirt_volume_default_device) == 'disk'
+  when: item.type | default(libvirt_volume_default_type) == 'volume'
   environment: "{{ libvirt_vm_script_env }}"
   register: volume_result
   changed_when:


### PR DESCRIPTION
Creating volumes only when the device is disk breaks the case where we
have a CDROM device backed by a volume.

Fixes: #45