### PR TITLE
Register newly modified hosts in new_instances

### DIFF
--- a/tasks/inventory_group.yml
+++ b/tasks/inventory_group.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Populate inventory group 'new_instances' for newly created instances
+  add_host:
+    name: "{{ item.vm.name }}"
+    groupname: "new_instances"
+  with_items: "{{ new_libvirt_instances.results }}"
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,10 @@
   loop_control:
     loop_var: vm
   when: (vm.state | default('present', true)) == 'present'
+  register: new_libvirt_instances
+
+- include_tasks: inventory_group.yml
+  with_items: "{{ new_libvirt_instances.results }}"
 
 - include_tasks: destroy-vm.yml
   with_items: "{{ libvirt_vms }}"


### PR DESCRIPTION
This allows following tasks to work with a group of hosts which have been
reported as relevant instead of surmising the system state from initial
configuration.