### PR TITLE
Don't assume English locale

### DIFF
--- a/files/virt_volume.sh
+++ b/files/virt_volume.sh
@@ -61,10 +61,6 @@ result=$?
 if [[ $result -eq 0 ]]; then
     echo '{"changed": false}'
     exit 0
-elif ! echo "$output" | grep 'Storage volume not found' >/dev/null 2>&1; then
-    echo "Unexpected error while getting volume info" >&2
-    echo "$output"
-    exit $result
 fi
 
 # Stop here in check mode, there will be a change


### PR DESCRIPTION
We currently check the output of 'virsh vol-info' for an expected error
message when checking for the presence of a volume. In non-English
locales, this will not work.

This change fixes the issue by assuming a failure of the command means
that the volume does not exist. If there is another cause, this should
be picked up when the volume is created.

Fixes: #51