### PR TITLE
Fix receiving multicast traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Role Variables
 - `libvirt_vm_clock_offset`. If defined the instances clock offset is set to
   the provided value. When undefined sync is set to `localtime`.
 
+- `libvirt_vm_trust_guest_rx_filters`: Whether to trust guest receive filters.
+  This gets mapped to the `trustGuestRxFilters` attribute of VM interfaces.
+  Default is `false`
+
 - `libvirt_vms`: list of VMs to be created/destroyed. Each one may have the
   following attributes:
 
@@ -110,7 +114,9 @@ Role Variables
             - `mode`: options include `vepa`, `bridge`, `private` and
               `passthrough`. See `man virsh` for more details. Default is
               `vepa`.
-
+        - `trust_guest_rx_filters`: Whether to trust guest receive filters.
+          This gets mapped to the `trustGuestRxFilters` attribute of VM
+          interfaces.  Default is `libvirt_vm_trust_guest_rx_filters`.
     - `console_log_enabled`: if `true`, log console output to a file at the
       path specified by `console_log_path`, **instead of** to a PTY. If
       `false`, direct terminal output to a PTY at serial port 0. Default is

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,10 @@ libvirt_vm_emulator:
 # configuration use <clock offset="specified offset">
 libvirt_vm_clock_offset: False
 
+# Default value for whether to trust guest receive filters. This gets mapped to
+# the trustGuestRxFilters attribute of VM interfaces.
+libvirt_vm_trust_guest_rx_filters: false
+
 # A list of specifications of VMs to be created.
 # For backwards compatibility, libvirt_vms defaults to a singleton list using
 # the values of the deprecated variables below.

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -47,7 +47,7 @@
 {% endfor %}
 {% for interface in interfaces %}
 {% if interface.type is defined and interface.type == 'direct' %}
-    <interface type='direct'>
+    <interface type='direct' {% if interface.trust_guest_rx_filters | default(libvirt_vm_trust_guest_rx_filters) | bool %}trustGuestRxFilters='yes'{% endif %}>
       <source dev='{{ interface.source.dev }}' mode='{{ interface.source.mode | default('vepa') }}'/>
 {% elif interface.type is defined and interface.type == 'bridge' %}
     <interface type='bridge'>


### PR DESCRIPTION
By default libvirt does not allow traffic destined for other MAC
addresses to reach VMs when using a macvtap interface. This prevents
multicast from working.

This change fixes the issue by setting trustGuestRxFilters to yes for
macvtap interfaces.