### PR TITLE
network storage fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,19 +201,6 @@ Example Playbook
                   auth:
                     username: 'admin'
                     type: 'ceph'
-                    uuid: ''
-                  source:
-                    protocol: 'rbd'
-                    name: 'rbd/bigstore'
-                    hostname: 'ceph.example.org'
-                    port: '6789'
-                - name: 'networkfs2'
-                  type: 'network'
-                  format: 'raw'
-                  capacity: '50G'
-                  auth:
-                    username: 'admin'
-                    type: 'ceph'
                     usage: 'rbd-pool'
                   source:
                     protocol: 'rbd'

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Role Variables
           `libvirt_volume_default_device` are valid here. Default is
           `libvirt_volume_default_type`.
         - `capacity`: volume capacity, can be suffixed with k, M, G, T, P or E when type is `network` or MB,GB,TB, etc when type is `disk` (required when type is `disk` or `network`)
-        - `auth`: Authentication details should they be required. If auth is required, `name`, `type`, `token` will need to be supplied.
+        - `auth`: Authentication details should they be required. If auth is required, `name`, `type`, and `token` or `usage` will need to be supplied. `token` and `usage` should not be both supplied.
         - `source`: Where the remote volume comes from when type is `network`. `protocol`, `name`, `hostname` and `port` should be supplied.
         - `format`: Format of the volume. All options for
           `libvirt_volume_default_format` are valid here. Default is

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Role Variables
           `libvirt_volume_default_device` are valid here. Default is
           `libvirt_volume_default_type`.
         - `capacity`: volume capacity, can be suffixed with k, M, G, T, P or E when type is `network` or MB,GB,TB, etc when type is `disk` (required when type is `disk` or `network`)
-        - `auth`: Authentication details should they be required. If auth is required, `name`, `type`, and `token` or `usage` will need to be supplied. `token` and `usage` should not be both supplied.
+        - `auth`: Authentication details should they be required. If auth is required, `username`, `type`, and `uuid` or `usage` will need to be supplied. `uuid` and `usage` should not be both supplied.
         - `source`: Where the remote volume comes from when type is `network`. `protocol`, `name`, and `hostname` or `hosts_list` should be supplied. `hostname` and `hosts_list` should not be both supplied. `port` is optional.
         - `format`: Format of the volume. All options for
           `libvirt_volume_default_format` are valid here. Default is
@@ -199,9 +199,9 @@ Example Playbook
                   format: 'raw'
                   capacity: '50G'
                   auth:
-                    name: 'admin'
+                    username: 'admin'
                     type: 'ceph'
-                    token: ''
+                    uuid: ''
                   source:
                     protocol: 'rbd'
                     name: 'rbd/bigstore'
@@ -212,7 +212,7 @@ Example Playbook
                   format: 'raw'
                   capacity: '50G'
                   auth:
-                    name: 'admin'
+                    username: 'admin'
                     type: 'ceph'
                     usage: 'rbd-pool'
                   source:

--- a/README.md
+++ b/README.md
@@ -207,6 +207,22 @@ Example Playbook
                     name: 'rbd/bigstore'
                     hostname: 'ceph.example.org'
                     port: '6789'
+                - name: 'networkfs2'
+                  type: 'network'
+                  format: 'raw'
+                  capacity: '50G'
+                  auth:
+                    name: 'admin'
+                    type: 'ceph'
+                    usage: 'rbd-pool'
+                  source:
+                    protocol: 'rbd'
+                    name: 'rbd/volume'
+                    hosts_list:
+                      - 'mon1.example.org'
+                      - 'mon2.example.org'
+                      - 'mon3.example.org'
+ 
               interfaces:
                 - network: 'br-datacentre'
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Role Variables
           `libvirt_volume_default_type`.
         - `capacity`: volume capacity, can be suffixed with k, M, G, T, P or E when type is `network` or MB,GB,TB, etc when type is `disk` (required when type is `disk` or `network`)
         - `auth`: Authentication details should they be required. If auth is required, `username`, `type`, and `uuid` or `usage` will need to be supplied. `uuid` and `usage` should not be both supplied.
-        - `source`: Where the remote volume comes from when type is `network`. `protocol`, `name`, and `hostname` or `hosts_list` should be supplied. `hostname` and `hosts_list` should not be both supplied. `port` is optional.
+        - `source`: Where the remote volume comes from when type is `network`. `protocol`, `name` and `hosts_list` should be supplied. `port` is optional.
         - `format`: Format of the volume. All options for
           `libvirt_volume_default_format` are valid here. Default is
           `libvirt_volume_default_format`.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Role Variables
           `libvirt_volume_default_type`.
         - `capacity`: volume capacity, can be suffixed with k, M, G, T, P or E when type is `network` or MB,GB,TB, etc when type is `disk` (required when type is `disk` or `network`)
         - `auth`: Authentication details should they be required. If auth is required, `name`, `type`, and `token` or `usage` will need to be supplied. `token` and `usage` should not be both supplied.
-        - `source`: Where the remote volume comes from when type is `network`. `protocol`, `name`, `hostname` and `port` should be supplied.
+        - `source`: Where the remote volume comes from when type is `network`. `protocol`, `name`, and `hostname` or `hosts_list` should be supplied. `hostname` and `hosts_list` should not be both supplied. `port` is optional.
         - `format`: Format of the volume. All options for
           `libvirt_volume_default_format` are valid here. Default is
           `libvirt_volume_default_format`.

--- a/tasks/volumes.yml
+++ b/tasks/volumes.yml
@@ -27,7 +27,7 @@
     {% endif %}
     -a {{ ansible_check_mode }}
   with_items: "{{ volumes }}"
-  when: item.type | default(libvirt_volume_default_type) in ['volume', 'network']
+  when: item.type | default(libvirt_volume_default_type) == 'volume'
   environment: "{{ libvirt_vm_script_env }}"
   register: volume_result
   changed_when:

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -51,7 +51,7 @@
           {% if volume.source.hosts_list is defined and volume.source.hosts_list is not none %}
           {% for host in volume.source.hosts_list %}
           <host name='{{ host }}' {% if volume.source.port is defined and volume.source.port is not none %} port='{{ volume.source.port }}' {% endif %}/>
-	  {% endfor %}
+	      {% endfor %}
           {% else %}
           <host name='{{ volume.source.hostname }}' {% if volume.source.port is defined and volume.source.port is not none %} port='{{ volume.source.port }}' {% endif %}/>
           {% endif %}

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -48,7 +48,13 @@
         {% endif %} {# End volume.auth.name check #}
         {% if volume.source.name is defined %}
         <source protocol='{{ volume.source.protocol }}' name='{{ volume.source.name }}'>
-          <host name='{{ volume.source.hostname }}' port='{{ volume.source.port }}'/>
+          {% if volume.source.hosts_list is defined and volume.source.hosts_list is not none %}
+          {% for host in volume.source.hosts_list %}
+          <host name='{{ host }}' {% if volume.source.port is defined and volume.source.port is not none %} port='{{ volume.source.port }}' {% endif %}/>
+	  {% endfor %}
+          {% else %}
+          <host name='{{ volume.source.hostname }}' {% if volume.source.port is defined and volume.source.port is not none %} port='{{ volume.source.port }}' {% endif %}/>
+          {% endif %}
         </source>
         {% endif %} {# End volume.source.name check #}
       {% else %} {# End elif volume.type is defined #}

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -48,13 +48,9 @@
         {% endif %} {# End volume.auth.username check #}
         {% if volume.source.name is defined %}
         <source protocol='{{ volume.source.protocol }}' name='{{ volume.source.name }}'>
-          {% if volume.source.hosts_list is defined and volume.source.hosts_list is not none %}
           {% for host in volume.source.hosts_list %}
           <host name='{{ host }}' {% if volume.source.port is defined and volume.source.port is not none %} port='{{ volume.source.port }}' {% endif %}/>
-	      {% endfor %}
-          {% else %}
-          <host name='{{ volume.source.hostname }}' {% if volume.source.port is defined and volume.source.port is not none %} port='{{ volume.source.port }}' {% endif %}/>
-          {% endif %}
+          {% endfor %}
         </source>
         {% endif %} {# End volume.source.name check #}
       {% else %} {# End elif volume.type is defined #}

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -41,11 +41,11 @@
       {% if volume.type | default(libvirt_volume_default_type) == 'file' %}
       <source file='{{ volume.file_path |default(libvirt_volume_default_images_path) }}/{{ volume.name}}'/>
       {% elif volume.type is defined and volume.type == 'network' %}
-        {% if volume.auth.name is defined %}
-        <auth username='{{ volume.auth.name }}'>
-          <secret type='{{ volume.auth.type }}' {% if volume.auth.token is defined and volume.auth.token is not none %} uuid='{{ volume.auth.token }}' {% else %} usage='{{ volume.auth.usage }}' {% endif %}/>
+        {% if volume.auth.username is defined %}
+        <auth username='{{ volume.auth.username }}'>
+          <secret type='{{ volume.auth.type }}' {% if volume.auth.uuid is defined and volume.auth.uuid is not none %} uuid='{{ volume.auth.uuid }}' {% else %} usage='{{ volume.auth.usage }}' {% endif %}/>
         </auth>
-        {% endif %} {# End volume.auth.name check #}
+        {% endif %} {# End volume.auth.username check #}
         {% if volume.source.name is defined %}
         <source protocol='{{ volume.source.protocol }}' name='{{ volume.source.name }}'>
           {% if volume.source.hosts_list is defined and volume.source.hosts_list is not none %}

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -43,7 +43,7 @@
       {% elif volume.type is defined and volume.type == 'network' %}
         {% if volume.auth.name is defined %}
         <auth username='{{ volume.auth.name }}'>
-          <secret type='{{ volume.auth.type }}' uuid='{{ volume.auth.token }}'/>
+          <secret type='{{ volume.auth.type }}' {% if volume.auth.token is defined and volume.auth.token is not none %} uuid='{{ volume.auth.token }}' {% else %} usage='{{ volume.auth.usage }}' {% endif %}/>
         </auth>
         {% endif %} {# End volume.auth.name check #}
         {% if volume.source.name is defined %}


### PR DESCRIPTION
Hello, I fixed some stuff in the network storage support:

- I added the possibility to use the `usage` property instead of the UUID.
- I added the possibility to give a list of hosts in the source instead of a simple hostname.
- I made `port` property facultative, libvirt can use protocol default port without problem.
- I fixed an error that launched the volume creation script even for network storage.

ALso I wish to share the list of parameters in the `auth` section that are wrongly named, but cannot be changed because it would imply some breaking changes:

- `name` should be named `username` to avoid confusion with secret name.
- `token` should be named `uuid`, that's the terminology in libvirt documentation, there isn't any token anywhere.

If there is a way to change that, I think that would be much more explicit.