### PR TITLE
Add a option to use checksum on get_url in tasks Ensure remote images are downloaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Role Variables
           `libvirt_volume_default_format` are valid here. Default is
           `libvirt_volume_default_format`.
         - `image`: (optional) a URL to an image with which the volume is initalised (full copy).
+        - `checksum`: (optional) checksum of the `image` to avoid download when it's not necessary.
         - `backing_image`: (optional) name of the backing volume which is assumed to already be the same pool (copy-on-write).
         - `image` and `backing_image` are mutually exclusive options.
         - `target`: (optional) Manually influence type and order of volumes

--- a/tasks/volumes.yml
+++ b/tasks/volumes.yml
@@ -9,10 +9,11 @@
 
 - name: Ensure local images are copied
   copy:
-    src: "{{ item }}"
-    dest: "{{ libvirt_vm_image_cache_path }}/{{ item | basename }}"
-  with_items: "{{ volumes | selectattr('image', 'defined') | map(attribute='image') | list }}"
-  when: "'http' not in item"
+    src: "{{ item.image }}"
+    dest: "{{ libvirt_vm_image_cache_path }}/{{ item.image | basename }}"
+    checksum: "{{ item.checksum | default(omit) }}"
+  with_items: "{{ volumes | selectattr('image', 'defined') | list }}"
+  when: "'http' not in item.image"
 
 - name: Ensure the VM disk volumes exist
   script: >

--- a/tasks/volumes.yml
+++ b/tasks/volumes.yml
@@ -1,10 +1,11 @@
 ---
 - name: Ensure remote images are downloaded
   get_url:
-    url: "{{ item }}"
-    dest: "{{ libvirt_vm_image_cache_path }}/{{ item | basename }}"
-  with_items: "{{ volumes | selectattr('image', 'defined') | map(attribute='image') | list }}"
-  when: "'http' in item"
+    url: "{{ item.image }}"
+    dest: "{{ libvirt_vm_image_cache_path }}/{{ item.image | basename }}"
+    checksum: "{{ item.checksum | default(omit) }}"
+  with_items: "{{ volumes | selectattr('image', 'defined') | list }}"
+  when: "'http' in item.image"
 
 - name: Ensure local images are copied
   copy:


### PR DESCRIPTION
Add a optional new field in volume : **checksum**, it's will avoid downloading images when it's not need.
Can be use like this :  
```
  volumes:
    - name: 'debian-10.5.0-amd64-netinst.iso'
      image: https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-10.5.0-amd64-netinst.iso
      checksum: sha256:93863e17ac24eeaa347dfb91dddac654f214c189e0379d7c28664a306e0301e7
```