### PR TITLE
Don't use name in `define`

### DIFF
--- a/tasks/vm.yml
+++ b/tasks/vm.yml
@@ -18,7 +18,6 @@
 
 - name: Ensure the VM is defined
   virt:
-    name: "{{ vm.name }}"
     command: define
     xml: "{{ lookup('template', vm.xml_file | default('vm.xml.j2')) }}"
     uri: "{{ libvirt_vm_uri | default(omit, true) }}"


### PR DESCRIPTION
This raises a warning