### PR TITLE
Only destroy volumes of type volume or network

### DIFF
--- a/tasks/destroy-volumes.yml
+++ b/tasks/destroy-volumes.yml
@@ -3,7 +3,7 @@
   script: >
     destroy_virt_volume.sh
     {{ item.name }}
-    {{ item.pool }}
+    {{ item.pool | default('default') }}
   with_items: "{{ volumes }}"
   when: item.type | default(libvirt_volume_default_type) in ['volume', 'network']
   register: volume_result

--- a/tasks/destroy-volumes.yml
+++ b/tasks/destroy-volumes.yml
@@ -5,7 +5,7 @@
     {{ item.name }}
     {{ item.pool | default('default') }}
   with_items: "{{ volumes }}"
-  when: item.type | default(libvirt_volume_default_type) in ['volume', 'network']
+  when: item.type | default(libvirt_volume_default_type) == 'volume'
   register: volume_result
   environment: "{{ libvirt_vm_script_env }}"
   changed_when:

--- a/tasks/destroy-volumes.yml
+++ b/tasks/destroy-volumes.yml
@@ -5,6 +5,7 @@
     {{ item.name }}
     {{ item.pool }}
   with_items: "{{ volumes }}"
+  when: item.type | default(libvirt_volume_default_type) in ['volume', 'network']
   register: volume_result
   environment: "{{ libvirt_vm_script_env }}"
   changed_when:


### PR DESCRIPTION
Other volume types (e.g. file) do not need to be destroyed.

Fixes: #73