### PR TITLE
Allow uploading volumes from host that launched the playbook  

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Role Variables
         - `image` and `backing_image` are mutually exclusive options.
         - `target`: (optional) Manually influence type and order of volumes
         - `dev`: (optional) Block device path when type is `block`.
+        - `remote_src`: (optional) When type is `file` or `block`, specify wether `image` points to a remote file (true) or a file local to the host that launched the playbook (false). Defaults to true.
+
 
     - `interfaces`: a list of network interfaces to attach to the VM.
       Each network interface is defined with the following dict:

--- a/tasks/volumes.yml
+++ b/tasks/volumes.yml
@@ -12,7 +12,7 @@
     src: "{{ item.image }}"
     dest: "{{ libvirt_vm_image_cache_path }}/{{ item.image | basename }}"
     checksum: "{{ item.checksum | default(omit) }}"
-    remote_src: true
+    remote_src: "{{ item.remote_src | default(true) | bool }}"
   with_items: "{{ volumes | selectattr('image', 'defined') | list }}"
   when: "'http' not in item.image"
 


### PR DESCRIPTION
For example if I have a file `my-cloud-image.qcow2` (in the same directory as my playbook) that I want to create a new VM and boot from and I have two storage pools configured: `"vms"` (`/var/lib/libvirt/vms`) and `"images"` (`/var/lib/libvirt/images`)

```
libvirt_vm_image_cache_path: /var/lib/libvirt/images                                                                                                                                                         
libvirt_vms:                                                                                                                                                                                                 
  - name: test.example.com                                                                                                                                                                          
    state: present                                                                                                                                                                                           
    memory_mb: 4096                                                                                                                                                                                          
    vcpus: 2                                                                                                                                                                                                                                                                                                                                                                              
    volumes:                                                                                                                                                                                                                                                                                                                                              
      - name: test.example.com-root-disk                                                                                                                                                                        
        type: volume                                                                                                                                                                                         
        checksum: f3cd51fag5a6561d2e49e40d026625948c642c57                                                                                                                                                   
        capacity: 25GB                                                                                                                                                                                       
        format: qcow2                                                                                                                                                                                        
        pool: vms                                                                                                                                                                                            
        image: my-cloud-image.qcow2                                                                                                                                       
        remote_src: false 
```

With this patch, `my-cloud-image.qcow2` would be copied to `/var/lib/libvirt/images` and `/var/lib/libvirt/vms/test.example.com-root-disk` would be created from it as the boot disk.                                                                                                           