### PR TITLE
Use ansible_facts to reference facts

### DIFF
--- a/tasks/autodetect.yml
+++ b/tasks/autodetect.yml
@@ -15,7 +15,7 @@
     - name: Set a fact containing the virtualisation engine
       set_fact:
         libvirt_vm_engine: >-
-          {%- if ansible_architecture != libvirt_vm_arch -%}
+          {%- if ansible_facts.architecture != libvirt_vm_arch -%}
           {# Virtualisation instructions are generally available only for the host
           architecture. Ideally we would test for virtualisation instructions, eg. vt-d
           as it is possible that another architecture could support these even
@@ -59,8 +59,8 @@
           when: kvm_emulator_result.stat.exists
       when:
         - libvirt_vm_engine == 'qemu'
-        - ansible_os_family == 'RedHat'
-        - ansible_distribution_major_version | int >= 8
+        - ansible_facts.os_family == 'RedHat'
+        - ansible_facts.distribution_major_version | int >= 8
 
     - block:
         - name: Detect the QEMU emulator binary path
@@ -74,7 +74,7 @@
 
       when:
         - libvirt_vm_engine == 'qemu'
-        - ansible_os_family != 'RedHat' or ansible_distribution_major_version | int == 7
+        - ansible_facts.os_family != 'RedHat' or ansible_facts.distribution_major_version | int == 7
 
     - name: Fail if unable to detect the emulator
       fail:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,9 +3,9 @@
   include_vars: "{{ item }}"
   with_first_found:
     - files:
-        - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-        - "{{ ansible_distribution }}.yml"
-        - "{{ ansible_os_family }}.yml"
+        - "{{ ansible_facts.distribution }}-{{ ansible_facts.distribution_major_version }}.yml"
+        - "{{ ansible_facts.distribution }}.yml"
+        - "{{ ansible_facts.os_family }}.yml"
   tags: vars
 
 - include_tasks: autodetect.yml
@@ -18,8 +18,8 @@
 # Libvirt requires qemu-img to create qcow2 files.
 - name: Ensure qemu-img is installed
   package:
-    name: "{{ 'qemu-img' if ansible_os_family == 'RedHat' else 'qemu-utils' }}"
-    update_cache: "{{ True if ansible_pkg_mgr == 'apt' else omit }}"
+    name: "{{ 'qemu-img' if ansible_facts.os_family == 'RedHat' else 'qemu-utils' }}"
+    update_cache: "{{ True if ansible_facts.pkg_mgr == 'apt' else omit }}"
   become: true
 
 - include_tasks: volumes.yml


### PR DESCRIPTION
By default, Ansible injects a variable for every fact, prefixed with
ansible_. This can result in a large number of variables for each host,
which at scale can incur a performance penalty. Ansible provides a
configuration option [0] that can be set to False to prevent this
injection of facts. In this case, facts should be referenced via
ansible_facts.<fact>.

This change updates all references to Ansible facts within Kolla Ansible
from using individual fact variables to using the items in the
ansible_facts dictionary. This allows users to disable fact variable
injection in their Ansible configuration, which may provide some
performance improvement.

This change disables fact variable injection in the ansible
configuration used in CI, to catch any attempts to use the injected
variables.

[0] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars