### PR TITLE
Add basic support for custom dmi informations

### DIFF
--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -22,7 +22,21 @@
     <boot dev='cdrom'/>
     <boot dev='network'/>
     <bios useserial='yes'/>
+    {% if vm.sysinfo is defined %}
+    <smbios mode='sysinfo'/>
+    {% endif %}
   </os>
+  {% if vm.sysinfo is defined %}
+  <sysinfo type='smbios'>
+    {% for block_name, block_content in vm.sysinfo %}
+    <{{ block_name }}>
+        {% for entry in {{ block_content }} %}
+        <entry {% if entry.name is defined %}name="{{ entry.name }}"{% endif %}>{{ entry.value }}</entry>
+        {% endfor %}
+    </{{ block_name }}>
+    {% endfor %}
+  </sysinfo>
+  {% endif %}
   <features>
     <acpi/>
     <apic/>


### PR DESCRIPTION
Add a simple array that can be used to pass custom DMI information to a VM.
This can be useful for automatic provisioning such as forwarding host names, IP addresses, and other custom information.

See libvirt doc on this https://libvirt.org/formatdomain.html#smbios-system-information
