### PR TITLE
Add efi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ Role Variables
     - `autostart`: Whether to start the VM when the host starts up. Default is
       `true`.
 
+    - `boot_firmware`: Can be one of: `bios`, or `efi`. Defaults to `bios`.
+
     - `xml_file`: Optionally supply a modified XML template. Base customisation
       off the default `vm.xml.j2` template so as to include the expected jinja
       expressions the role uses.
@@ -226,7 +228,7 @@ Example Playbook
                 - type: 'block'
                   format: 'raw'
                   dev: '/dev/sda'
- 
+
               interfaces:
                 - network: 'br-datacentre'
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,6 +86,9 @@ libvirt_vms:
       # XML template file to source domain definition
       xml_file: vm.xml.j2
       
+      # May be one of: bios, or efi.
+      boot_firmware: bios
+
 # Variables to add to the enviroment that is used to execute virsh commands
 libvirt_vm_virsh_default_env: "{{  { 'LIBVIRT_DEFAULT_URI': libvirt_vm_uri } if libvirt_vm_uri else {} }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,6 +45,7 @@
     autostart: "{{ vm.autostart | default(true) }}"
     enable_vnc: "{{ vm.enable_vnc | default(false) }}"
     enable_spice: "{{ vm.enable_spice | default(false) }}"
+    boot_firmware: "{{ vm.boot_firmware | default('bios', true) | lower }}"
   with_items: "{{ libvirt_vms }}"
   loop_control:
     loop_var: vm

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -22,6 +22,12 @@
     <boot dev='cdrom'/>
     <boot dev='network'/>
     <bios useserial='yes'/>
+    {% if boot_firmware == "efi"  %}
+      {# NOTE: pflash requires qemu 1.6 or newer. There are alternatives for older versions, but
+               they do not work with secure boot. See OVMF readme for an overview #}
+      <loader readonly='yes' type='pflash'>{{ libvirt_vm_ovmf_efi_firmware_path }}</loader>
+      <nvram template='{{ libvirt_vm_ovmf_efi_variable_store_path }}'/>
+    {% endif %}
   </os>
   <features>
     <acpi/>

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -10,3 +10,10 @@ libvirt_vm_script_env: >-
 
 # Archlinux qemu comes with kvm support compiled in
 libvirt_vm_emulator: /usr/bin/qemu-system-x86_64
+
+# Path to template OVMF efi variable store. A copy will be created
+# for each VM created.
+libvirt_vm_ovmf_efi_variable_store_path: /usr/share/OVMF/OVMF_VARS.fd
+
+# Path to OVMF efi firmware
+libvirt_vm_ovmf_efi_firmware_path: /usr/share/OVMF/OVMF_CODE.fd

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -10,3 +10,10 @@ libvirt_vm_script_env_debian:
 
 libvirt_vm_script_env: >-
   {{ libvirt_vm_script_env_debian | combine(libvirt_vm_virsh_default_env) }}
+
+# Path to template OVMF efi variable store. A copy will be created
+# for each VM created.
+libvirt_vm_ovmf_efi_variable_store_path: /usr/share/OVMF/OVMF_VARS.fd
+
+# Path to OVMF efi firmware
+libvirt_vm_ovmf_efi_firmware_path: /usr/share/OVMF/OVMF_CODE.fd

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -10,3 +10,10 @@ libvirt_vm_script_env_redhat:
 
 libvirt_vm_script_env: >-
   {{ libvirt_vm_script_env_redhat | combine(libvirt_vm_virsh_default_env) }}
+
+# Path to template OVMF efi variable store. A copy will be created
+# for each VM created.
+libvirt_vm_ovmf_efi_variable_store_path: /usr/share/edk2/ovmf/OVMF_VARS.fd
+
+# Path to OVMF efi firmware
+libvirt_vm_ovmf_efi_firmware_path: /usr/share/edk2/ovmf/OVMF_CODE.cc.fd


### PR DESCRIPTION
Add support for booting VMs in EFI mode.

Currently secure boot is not supported.

If using with the stackhpc.libvirt-host role, set
libvirt_host_enable_efi_support to true to install required packages.

Co-Authored-By: Mark Goddard <mark@stackhpc.com>