### PR TITLE
Fix undefining libvirt VMs with EFI boot firmware

### DIFF
--- a/tasks/destroy-vm.yml
+++ b/tasks/destroy-vm.yml
@@ -17,10 +17,19 @@
         uri: "{{ libvirt_vm_uri | default(omit, true) }}"
       become: yes
 
+    # note(wszumski): the virt module does not seem to support
+    # removing vms with nvram defined - as a workaround, use the
+    # virsh cli directly. It may be better to detect if dumpxml
+    # actually contains an nvram element rather than relying on
+    # boot_firmware having the correct value.
     - name: Ensure the VM is undefined
-      virt:
-        name: "{{ vm.name }}"
-        command: undefine
-        uri: "{{ libvirt_vm_uri | default(omit, true) }}"
+      command:
+        cmd: >-
+          virsh
+          {% if libvirt_vm_uri %}-c {{ libvirt_vm_uri }}{% endif %}
+          undefine
+          {% if boot_firmware == 'efi' %} --nvram{% endif %}
+          {{ vm.name }}
       become: yes
+      changed_when: true
   when: vm.name in result.list_vms

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,6 +52,8 @@
   when: (vm.state | default('present', true)) == 'present'
 
 - include_tasks: destroy-vm.yml
+  vars:
+    boot_firmware: "{{ vm.boot_firmware | default('bios', true) | lower }}"
   with_items: "{{ libvirt_vms }}"
   loop_control:
     loop_var: vm


### PR DESCRIPTION
The virt module does not seem to support removing VMs with NVRAM
defined. As a workaround, use the virsh cli directly.

Co-Authored-By: Will Szumski <will@stackhpc.com>