### PR TITLE
Add usb support to libvirt-vm role

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,27 @@ Role Variables
         - `dev`: (optional) Block device path when type is `block`.
         - `remote_src`: (optional) When type is `file` or `block`, specify wether `image` points to a remote file (true) or a file local to the host that launched the playbook (false). Defaults to true.
 
+    - `usb_devices`: a list of usb devices to present to the vm from the host.
+
+      Each usb device is defined with the following dict:
+
+        - `vendor`: The vendor id of the USB device. 
+        - `product`: The product id of the USB device.
+      
+      Note - Libvirt will error if the VM is provisioned and the USB device is not attached.
+
+      To obtain the vendor id and product id of the usb device from the host running as sudo / root with the usb device plugged in
+      run `lsusb -v`. Example below with an attached Sandisk USB Memory Stick with vendor id: `0x0781` and product id: `0x5567`
+
+      ```
+      lsusb -v | grep -A4 -i sandisk
+
+        idVendor           0x0781 SanDisk Corp.
+        idProduct          0x5567 Cruzer Blade
+        bcdDevice            1.00
+        iManufacturer           1 
+        iProduct                2 
+      ```
 
     - `interfaces`: a list of network interfaces to attach to the VM.
       Each network interface is defined with the following dict:
@@ -231,6 +252,10 @@ Example Playbook
 
               interfaces:
                 - network: 'br-datacentre'
+              
+              usb_devices:
+                - vendor: '0x0781'
+                  product: '0x5567'
 
             - state: present
               name: 'vm2'

--- a/tasks/check-usb-devices.yml
+++ b/tasks/check-usb-devices.yml
@@ -1,0 +1,15 @@
+---
+- name: List USB hardware
+  command: lsusb  -d {{ usb_device.vendor }}:{{ usb_device.product }}
+  register: host_attached_usb_device
+  become: true
+  changed_when: false 
+  ignore_errors: true
+
+- name: Check USB device is present on Host system
+  fail:
+    msg: >
+      The USB Device with Vendor ID:{{ usb_device.vendor }} and Product ID:{{ usb_device.product }} is not seen on host system
+      Is the USB device plugged in correctly ?
+  when:
+    - host_attached_usb_device.rc != 0

--- a/tasks/check-usb-devices.yml
+++ b/tasks/check-usb-devices.yml
@@ -4,7 +4,7 @@
   register: host_attached_usb_device
   become: true
   changed_when: false 
-  ignore_errors: true
+  failed_when: false
 
 - name: Check USB device is present on Host system
   fail:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,7 @@
     cpu_mode: "{{ vm.cpu_mode | default(libvirt_cpu_mode_default) }}"
     volumes: "{{ vm.volumes | default([], true) }}"
     interfaces: "{{ vm.interfaces | default([], true) }}"
+    usb_devices: "{{ vm.usb_devices | default([], false) }}"
     start: "{{ vm.start | default(true) }}"
     autostart: "{{ vm.autostart | default(true) }}"
     enable_vnc: "{{ vm.enable_vnc | default(false) }}"

--- a/tasks/vm.yml
+++ b/tasks/vm.yml
@@ -16,6 +16,12 @@
     interface: "{{ item }}"
   with_items: "{{ interfaces }}"
 
+- name: Validate Host USB Devices
+  include_tasks: check-usb-devices.yml
+  vars:
+    usb_device: "{{ item }}"
+  with_items: "{{ usb_devices }}"
+
 - name: Ensure the VM is defined
   virt:
     command: define

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -124,6 +124,15 @@
       <listen type='address'/>
     </graphics>
 {% endif %}
+{% for usb_device in usb_devices %}
+    <hostdev mode='subsystem' type='usb' managed='yes'>
+      <source>
+        <vendor id='{{ usb_device.vendor }}'/>
+        <product id='{{ usb_device.product }}'/>
+      </source>
+      <address type='usb' bus='0' port='{{ loop.index }}'/>
+    </hostdev>
+  {% endfor %}
     <rng model="virtio"><backend model="random">/dev/urandom</backend></rng>
   </devices>
 </domain>

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -130,7 +130,6 @@
         <vendor id='{{ usb_device.vendor }}'/>
         <product id='{{ usb_device.product }}'/>
       </source>
-      <address type='usb' bus='0' port='{{ loop.index }}'/>
     </hostdev>
   {% endfor %}
     <rng model="virtio"><backend model="random">/dev/urandom</backend></rng>


### PR DESCRIPTION
Hi

This PR adds functionality to pass through USB devices from Host to VM. I appreciate in a datacenter environment with many VMs this use case may be minimal but can still be a handy option to have for the VMs. As such I have made it transparent and skip over if there is not any usb_devices defined. 

I have also tried to follow the style and logic of this role in the way you use includes and generate vars for the additional USB parts. 

This has been tested with ansible without any usb_devices defined (skips tasks and is otherwise "transparent"), along with a combination of 1 and 2 USB devices with no errors. I have not tested if there is an upper limit for USB devices presented to a machine. Documentation for upper limit in KVM is a bit sparse. Happy to add an assert or validation if a limit is found. I would _hope_ most users want only a couple of devices to present to VMs

```
root@kvm-host-5ab7ea:~# virsh list
 Id   Name      State
-------------------------
 3    pfsense   running

root@kvm-host-5ab7ea:~# virsh dumpxml pfsense | grep -B2 -A5 0x0781
    <hostdev mode='subsystem' type='usb' managed='yes'>
      <source>
        <vendor id='0x0781'/>
        <product id='0x5567'/>
        <address bus='3' device='13'/>
      </source>
      <alias name='hostdev0'/>
      <address type='usb' bus='0' port='1'/>
```

 The main thing to be aware about is that Libvirt will complain if the devices are not present when the machine XML is generated - This is noted in the [commit](https://github.com/stackhpc/ansible-role-libvirt-vm/compare/master...gavinwill:ansible-role-libvirt-vm:add_usb_support?expand=1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) for the  REAMDE. 

Therefore to use the same approach as pre validating the network config with the include to task check-interface.yml, I have an include to check-usb-devices.yml which will validate the USB config before the VM XML task is generated / run. I have had to ignore errors for the output of lsusb and then present the "error" in a bit more of a  user friendly message.  

```
TASK [ansible-role-libvirt-vm : List USB hardware] ***********************************************************************************************************************************
task path: /Users/gavin/Documents/GIT/HomeLab/ansible/roles/ansible-role-libvirt-vm/tasks/check-usb-devices.yml:2
fatal: [kvm.gavinwill.me.uk]: FAILED! => {"changed": false, "cmd": ["lsusb", "-d", "0x0781:0x5567"], "delta": "0:00:00.008653", "end": "2023-03-12 17:54:24.967753", "msg": "non-zero return code", "rc": 1, "start": "2023-03-12 17:54:24.959100", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
...ignoring

TASK [ansible-role-libvirt-vm : Check USB device is present on Host system] **********************************************************************************************************
task path: /Users/gavin/Documents/GIT/HomeLab/ansible/roles/ansible-role-libvirt-vm/tasks/check-usb-devices.yml:9
fatal: [kvm.gavinwill.me.uk]: FAILED! => {"changed": false, "msg": "The USB Device with Vendor ID:0x0781 and Product ID:0x5567 is not seen on host system Is the USB device plugged in correctly ?\n"}
```

Happy to adjust this PR to match your requirements if there is anything else that may need changed otherwise hope you approve this PR and we can get the USB functionality added to the role in a new release. 

Many thanks for this role - It works well for my requirements at home
Gavin