### PR TITLE
Add switch for enabling qemu guest agent virtio channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Role Variables
     - `enable_spice`: If true enables SPICE listening for use with
       Virtual Machine Manager and similar tools
 
+    - `enable_guest_virtio`: If true enables guest virtio device for use with
+      Qemu guest agent
+
     - `volumes`: a list of volumes to attach to the VM.  Each volume is
       defined with the following dict:
         - `type`: What type of backing volume does the instance use? All

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,6 +46,7 @@
     autostart: "{{ vm.autostart | default(true) }}"
     enable_vnc: "{{ vm.enable_vnc | default(false) }}"
     enable_spice: "{{ vm.enable_spice | default(false) }}"
+    enable_guest_virtio: "{{ vm.enable_guest_virtio | default(false) }}"
     boot_firmware: "{{ vm.boot_firmware | default('bios', true) | lower }}"
   with_items: "{{ libvirt_vms }}"
   loop_control:

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -124,6 +124,11 @@
       <listen type='address'/>
     </graphics>
 {% endif %}
+{% if enable_guest_virtio |bool %}
+    <channel type='unix'>
+      <target type='virtio' name='org.qemu.guest_agent.0'/>
+    </channel>
+{% endif %}
 {% for usb_device in usb_devices %}
     <hostdev mode='subsystem' type='usb' managed='yes'>
       <source>


### PR DESCRIPTION
Hi,

This pull request adds a switch for enabling qemu guest agent virtio channel. This is, e.g., useful if you want to be able to connect to the VM with Ansible after creating it and without having SSH access. The qemu-guest-agent needs to be installed in the guest system to get it working.

Best regards,
Thomas