### PR TITLE
2M OVMF packages removed on Debian family

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -13,7 +13,7 @@ libvirt_vm_script_env: >-
 
 # Path to template OVMF efi variable store. A copy will be created
 # for each VM created.
-libvirt_vm_ovmf_efi_variable_store_path: /usr/share/OVMF/OVMF_VARS.fd
+libvirt_vm_ovmf_efi_variable_store_path: "/usr/share/OVMF/{{ 'OVMF_VARS_4M.fd' if ansible_facts.distribution_release == 'noble' else 'OVMF_VARS.fd' }}"
 
 # Path to OVMF efi firmware
-libvirt_vm_ovmf_efi_firmware_path: /usr/share/OVMF/OVMF_CODE.fd
+libvirt_vm_ovmf_efi_firmware_path: "/usr/share/OVMF/{{ 'OVMF_CODE_4M.fd' if ansible_facts.distribution_release == 'noble' else 'OVMF_CODE.fd' }}"


### PR DESCRIPTION
New ovmf packages no longer provide the files listed below on Ubuntu Noble:
 - /usr/share/OVMF/OVMF_CODE.fd
 - /usr/share/OVMF/OVMF_VARS.fd

Files below are to be used instead:
 - /usr/share/OVMF/OVMF_CODE_4m.fd 
 - /usr/share/OVMF/OVMF_VARS_4m.fd

```
$ zcat /usr/share/doc/ovmf/NEWS.Debian.gz 
edk2 (2023.11-2) unstable; urgency=medium

  The 2MB ovmf pflash images, OVMF_CODE.*.fd and OVMF_VARS.*.fd, have now
  been removed. Users of the 2MB pflash images should migrate to their 4MB
  image counterparts:

    OVMF_CODE.fd         -> OVMF_CODE_4M.fd
    OVMF_CODE.ms.fd      -> OVMF_CODE_4M.ms.fd
    OVMF_CODE.secboot.fd -> OVMF_CODE_4M.secboot.fd
    OVMF_VARS.fd         -> OVMF_VARS_4M.fd
    OVMF_VARS.ms.fd      -> OVMF_VARS_4M.ms.fd

  2MB VAR images are not compatible with 4MB CODE images. Users must
  migrate both CODE and VARS images simultaneously.

  A migration guide is provided at:
    /usr/share/doc/ovmf/howto-2M-to-4M-migration.md.gz

 -- dann frazier <dannf@debian.org>  Wed, 27 Dec 2023 10:15:33 -0700
```

