### PR TITLE
Add Cloud-init and TPM Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ be preconfigured with libvirt/KVM.
 
 `genisoimage` is required for cloud-init support.
 
+`swtpm` and `swtpm-tools` packages are required for TPM support.
+
 Role Variables
 --------------
 
@@ -203,6 +205,9 @@ Role Variables
 
     - `boot_firmware`: Can be one of: `bios`, or `efi`. Defaults to `bios`.
 
+    - `tpm_enabled`: Whether to enable TPM for this VM. Default is `false`.
+
+    - `tpm_version`: TPM version to use. Can be '1.2' or '2.0'. Default is '2.0'.
 
     - `cloud_init_enabled`: Whether to enable cloud-init for this VM. Default is `false`.
 
@@ -297,6 +302,8 @@ Example Playbook
                   type: 'file'
                   file_path: '/srv/cloud/images'
                   capacity: '900GB'
+              tpm_enabled: true
+              tpm_version: "2.0"
               cloud_init_enabled: true
               cloud_init_user_data:
                 users:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -102,6 +102,9 @@ libvirt_vm_sudo: true
 # Default CPU mode if libvirt_vm_cpu_mode or vm.cpu_mode is undefined
 libvirt_cpu_mode_default: "{{ 'host-passthrough' if libvirt_vm_engine == 'kvm' else 'host-model' }}"
 
+# Path where cloud-init files will be stored
+libvirt_vm_cloud_init_dir: "{{ libvirt_volume_default_images_path }}/cloud-init"
+
 ### DEPRECATED ###
 # Use the above settings for each item within `libvirt_vms`, instead of the
 # below deprecated variables.

--- a/tasks/check-interface.yml
+++ b/tasks/check-interface.yml
@@ -19,3 +19,15 @@
     - interface.type == 'direct'
     - interface.source is not defined or
       interface.source.dev is not defined
+
+- name: Validate network configuration requirements
+  ansible.builtin.fail:
+    msg: >
+      {% if vm.cloud_init_enabled | default(false) | bool and not (interface.alias is defined and interface.mac is defined) %}
+      When cloud-init is enabled, both 'alias' and 'mac' must be defined for all interfaces
+      {% elif not (vm.cloud_init_enabled | default(false) | bool) and (interface.address is defined or interface.gateway is defined or interface.nameservers is defined) %}
+      Cloud-init must be enabled when configuring network settings (address, gateway, or nameservers)
+      {% endif %}
+  when:
+    - vm.cloud_init_enabled | default(false) | bool and not (interface.alias is defined and interface.mac is defined) or
+      not (vm.cloud_init_enabled | default(false) | bool) and (interface.address is defined or interface.gateway is defined or interface.nameservers is defined)

--- a/tasks/cloud-init.yml
+++ b/tasks/cloud-init.yml
@@ -1,0 +1,51 @@
+---
+# Tasks for generating cloud-init configuration and ISO
+
+- name: Get VM UUID
+  ansible.builtin.command:
+    cmd: virsh -q domuuid {{ vm.name }}
+  register: vm_uuid
+  changed_when: false
+  failed_when: false
+
+- name: Ensure VM-specific cloud-init directory exists
+  ansible.builtin.file:
+    path: "{{ libvirt_vm_cloud_init_dir }}/{{ vm.name }}"
+    state: directory
+    mode: '0755'
+  become: "{{ libvirt_vm_sudo }}"
+
+- name: Generate cloud-init meta-data file
+  ansible.builtin.template:
+    src: cloud-init/meta-data.j2
+    dest: "{{ libvirt_vm_cloud_init_dir }}/{{ vm.name }}/meta-data"
+    mode: '0644'
+  become: "{{ libvirt_vm_sudo }}"
+  register: meta_data_task
+
+- name: Generate cloud-init user-data file
+  ansible.builtin.template:
+    src: cloud-init/user-data.j2
+    dest: "{{ libvirt_vm_cloud_init_dir }}/{{ vm.name }}/user-data"
+    mode: '0644'
+  become: "{{ libvirt_vm_sudo }}"
+  register: user_data_task
+
+- name: Generate cloud-init network-config file
+  ansible.builtin.template:
+    src: cloud-init/network-config.j2
+    dest: "{{ libvirt_vm_cloud_init_dir }}/{{ vm.name }}/network-config"
+    mode: '0644'
+  become: "{{ libvirt_vm_sudo }}"
+  register: network_config_task
+
+- name: Generate cloud-init ISO
+  ansible.builtin.command:
+    cmd: >-
+      genisoimage -output {{ libvirt_vm_cloud_init_dir }}/{{ vm.name }}/cloud-init.iso
+      -volid cidata -joliet -rock -input-charset utf-8
+      {{ libvirt_vm_cloud_init_dir }}/{{ vm.name }}/meta-data
+      {{ libvirt_vm_cloud_init_dir }}/{{ vm.name }}/user-data
+      {{ libvirt_vm_cloud_init_dir }}/{{ vm.name }}/network-config
+  become: "{{ libvirt_vm_sudo }}"
+  when: (cloud_init_enabled | bool) and (meta_data_task.changed or user_data_task.changed or network_config_task.changed) 

--- a/tasks/cloud-init.yml
+++ b/tasks/cloud-init.yml
@@ -39,6 +39,12 @@
   become: "{{ libvirt_vm_sudo }}"
   register: network_config_task
 
+- name: Check if cloud-init ISO exists
+  ansible.builtin.stat:
+    path: "{{ libvirt_vm_cloud_init_dir }}/{{ vm.name }}/cloud-init.iso"
+  become: "{{ libvirt_vm_sudo }}"
+  register: cloud_init_iso_exists
+
 - name: Generate cloud-init ISO
   ansible.builtin.command:
     cmd: >-
@@ -48,4 +54,4 @@
       {{ libvirt_vm_cloud_init_dir }}/{{ vm.name }}/user-data
       {{ libvirt_vm_cloud_init_dir }}/{{ vm.name }}/network-config
   become: "{{ libvirt_vm_sudo }}"
-  when: (cloud_init_enabled | bool) and (meta_data_task.changed or user_data_task.changed or network_config_task.changed) 
+  when: meta_data_task.changed or user_data_task.changed or network_config_task.changed or not cloud_init_iso_exists.stat.exists

--- a/tasks/destroy-vm.yml
+++ b/tasks/destroy-vm.yml
@@ -9,7 +9,7 @@
   register: result
   become: true
 
-- name: Destory the VM is existing
+- name: Destroy the VM if existing
   block:
     - name: Ensure the VM is absent
       community.libvirt.virt:
@@ -33,4 +33,10 @@
           {{ vm.name }}
       become: true
       changed_when: true
+
+    - name: Remove cloud-init directory
+      ansible.builtin.file:
+        path: "{{ libvirt_vm_cloud_init_dir }}/{{ vm.name }}"
+        state: absent
+      become: true
   when: vm.name in result.list_vms

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,6 +61,19 @@
     loop_var: vm
   when: (vm.state | default('present', true)) == 'present'
 
+- name: Remove cloud-init directory if disabled
+  ansible.builtin.file:
+    path: "{{ libvirt_vm_cloud_init_dir }}/{{ vm.name }}"
+    state: absent
+    mode: '0755'
+  become: "{{ libvirt_vm_sudo }}"
+  with_items: "{{ libvirt_vms }}"
+  loop_control:
+    loop_var: vm
+  when: >-
+    not (vm.cloud_init_enabled | default(false) | bool)
+    and (vm.state | default('present', true)) == 'present'
+
 - include_tasks: destroy-vm.yml
   vars:
     boot_firmware: "{{ vm.boot_firmware | default('bios', true) | lower }}"

--- a/tasks/vm.yml
+++ b/tasks/vm.yml
@@ -29,6 +29,10 @@
     uri: "{{ libvirt_vm_uri | default(omit, true) }}"
   become: "{{ libvirt_vm_sudo }}"
 
+- name: Include cloud-init tasks
+  ansible.builtin.include_tasks: cloud-init.yml
+  when: vm.cloud_init_enabled | default(false) | bool
+
 - name: Ensure the VM is running and started at boot
   community.libvirt.virt:
     name: "{{ vm.name }}"

--- a/templates/cloud-init/meta-data.j2
+++ b/templates/cloud-init/meta-data.j2
@@ -1,0 +1,7 @@
+{% if vm_uuid.rc == 0 %}
+instance-id: {{ vm_uuid.stdout }}
+{% else %}
+instance-id: {{ vm.name }}
+{% endif %}
+local-hostname: {{ vm.name }}
+{{ vm.cloud_init_meta_data | default({}) | to_nice_yaml(indent=2) }}

--- a/templates/cloud-init/network-config.j2
+++ b/templates/cloud-init/network-config.j2
@@ -13,7 +13,9 @@ ethernets:
     addresses:
       - {{ interface.address }}
 {% if interface.gateway is defined %}
-    gateway4: {{ interface.gateway }}
+    routes:
+      - to: default
+        via: {{ interface.gateway }}
 {% endif %}
 {% if interface.nameservers is defined %}
     nameservers:

--- a/templates/cloud-init/network-config.j2
+++ b/templates/cloud-init/network-config.j2
@@ -1,0 +1,30 @@
+version: 2
+{% if vm.cloud_init_network_config is defined %}
+{{ vm.cloud_init_network_config | to_nice_yaml(indent=2) }}
+{% else %}
+ethernets:
+{% for interface in interfaces %}
+{% if interface.alias is defined %}
+  {{ interface.alias }}:
+    match:
+      macaddress: "{{ interface.mac }}"
+    set-name: {{ interface.alias }}
+{% if interface.address is defined %}
+    addresses:
+      - {{ interface.address }}
+{% if interface.gateway is defined %}
+    gateway4: {{ interface.gateway }}
+{% endif %}
+{% if interface.nameservers is defined %}
+    nameservers:
+      addresses: {{ interface.nameservers }}
+{% endif %}
+{% else %}
+    dhcp4: true
+{% endif %}
+{% else %}
+  eth{{ loop.index0 }}:
+    dhcp4: true
+{% endif %}
+{% endfor %}
+{% endif %} 

--- a/templates/cloud-init/user-data.j2
+++ b/templates/cloud-init/user-data.j2
@@ -1,0 +1,2 @@
+#cloud-config
+{{ vm.cloud_init_user_data | default({}) | to_nice_yaml(indent=2) }} 

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -65,12 +65,20 @@
       <source pool='{{ volume.pool }}' volume='{{ volume.name }}'/>
       {% endif %}
       {% if volume.target is undefined %}
-      <target dev='vd{{ 'abcdefghijklmnopqrstuvwxyz'[loop.index - 1] }}' {% if volume.device | default(libvirt_volume_default_device) == 'cdrom' %}bus='sata'{% endif %}/>
+      <target dev='vd{{ 'abcdefghijklmnopqrstuvwxy'[loop.index - 1] }}' {% if volume.device | default(libvirt_volume_default_device) == 'cdrom' %}bus='sata'{% endif %}/>
       {% else %}
       <target dev='{{ volume.target }}' {% if volume.device | default(libvirt_volume_default_device) == 'cdrom' %}bus='sata'{% endif %}/>
       {% endif %}
     </disk>
 {% endfor %}
+{% if vm.cloud_init_enabled | default(false) | bool %}
+    <disk type='file' device='cdrom'>
+      <driver name='qemu' type='raw'/>
+      <source file='{{ libvirt_vm_cloud_init_dir }}/{{ vm.name }}/cloud-init.iso'/>
+      <target dev='vdz' bus='sata'/>
+      <readonly/>
+    </disk>
+{% endif %}
 {% for interface in interfaces %}
 {% if interface.type is defined and interface.type == 'direct' %}
     <interface type='direct' {% if interface.trust_guest_rx_filters | default(libvirt_vm_trust_guest_rx_filters) | bool %}trustGuestRxFilters='yes'{% endif %}>

--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -145,6 +145,11 @@
       </source>
     </hostdev>
   {% endfor %}
+    {% if vm.tpm_enabled | default(false) | bool %}
+    <tpm model='tpm-tis'>
+      <backend type='emulator' version='{{ vm.tpm_version | default("2.0") }}'/>
+    </tpm>
+    {% endif %}
     <rng model="virtio"><backend model="random">/dev/urandom</backend></rng>
   </devices>
 </domain>


### PR DESCRIPTION
## Description:
This pull request introduces two major enhancements to the libvirt_vm role: Cloud-init integration and TPM support.

1. Cloud-init Support:
- Added cloud-init integration for VM provisioning
- Implemented cloud-init configuration templates:
  - meta-data
  - user-data
  - network-config
- Enhanced VM destruction process to clean up cloud-init resources
- Updated network interface checking functionality
- Updated documentation with cloud-init configuration examples

2. TPM (Trusted Platform Module) Support:
- Added TPM device configuration in VM XML template
- Introduced new VM configuration parameters:
  - `tpm_enabled`: Toggle TPM support (default: false)
  - `tpm_version`: Select TPM version ('1.2' or '2.0', default: '2.0')

## Dependencies:
- `genisoimage` package is required for cloud-init support
- `swtpm` and `swtpm-tools` packages are required for TPM support

## Example Usage:
``` yaml
vm:
  name: example-vm
  # Cloud-init configuration
  cloud_init_enabled: true
  cloud_init_user_data:
    users:
      - name: myuser
        sudo: ALL=(ALL) NOPASSWD:ALL
  
  # TPM configuration
  tpm_enabled: true
  tpm_version: "2.0"
```
