### PR TITLE
Add default NVRAM template format

### DIFF
--- a/templates/vm.xml.j2
+++ b/templates/vm.xml.j2
@@ -26,7 +26,7 @@
       {# NOTE: pflash requires qemu 1.6 or newer. There are alternatives for older versions, but
                they do not work with secure boot. See OVMF readme for an overview #}
       <loader readonly='yes' type='pflash'>{{ libvirt_vm_ovmf_efi_firmware_path }}</loader>
-      <nvram template='{{ libvirt_vm_ovmf_efi_variable_store_path }}'/>
+      <nvram template='{{ libvirt_vm_ovmf_efi_variable_store_path }}' templateFormat='{{ libvirt_vm_ovmf_efi_variable_store_format }}'/>
     {% endif %}
   </os>
   <features>

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -15,5 +15,8 @@ libvirt_vm_emulator: /usr/bin/qemu-system-x86_64
 # for each VM created.
 libvirt_vm_ovmf_efi_variable_store_path: /usr/share/OVMF/OVMF_VARS.fd
 
+# Format of the template OVMF efi variable store.
+libvirt_vm_ovmf_efi_variable_store_format: raw
+
 # Path to OVMF efi firmware
 libvirt_vm_ovmf_efi_firmware_path: /usr/share/OVMF/OVMF_CODE.fd

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -15,5 +15,8 @@ libvirt_vm_script_env: >-
 # for each VM created.
 libvirt_vm_ovmf_efi_variable_store_path: "/usr/share/OVMF/{{ 'OVMF_VARS_4M.fd' if ansible_facts.distribution_release == 'noble' else 'OVMF_VARS.fd' }}"
 
+# Format of the template OVMF efi variable store.
+libvirt_vm_ovmf_efi_variable_store_format: raw
+
 # Path to OVMF efi firmware
 libvirt_vm_ovmf_efi_firmware_path: "/usr/share/OVMF/{{ 'OVMF_CODE_4M.fd' if ansible_facts.distribution_release == 'noble' else 'OVMF_CODE.fd' }}"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -15,5 +15,8 @@ libvirt_vm_script_env: >-
 # for each VM created.
 libvirt_vm_ovmf_efi_variable_store_path: /usr/share/edk2/ovmf/OVMF_VARS.fd
 
+# Format of the template OVMF efi variable store.
+libvirt_vm_ovmf_efi_variable_store_format: raw
+
 # Path to OVMF efi firmware
 libvirt_vm_ovmf_efi_firmware_path: /usr/share/edk2/ovmf/OVMF_CODE.cc.fd


### PR DESCRIPTION
This is required since Libvirt 10.10.0 [1] in Rocky Linux 9.6. It also appears to be safe to use on older Libvirt versions (tested on Ubuntu Noble and Jammy).

[1] https://gitlab.com/libvirt/libvirt/-/commit/2aa644a2fc8f1e9cd68bd4920bf3501f1a9cc506