### PR TITLE
Correct EFI vars for Debian 13

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -11,12 +11,15 @@ libvirt_vm_script_env_debian:
 libvirt_vm_script_env: >-
   {{ libvirt_vm_script_env_debian | combine(libvirt_vm_virsh_default_env) }}
 
+# Whether or not to use 4M OVMF vars/firmware
+__libvirt_vm_ovmf_debian_4m_efivars: >-
+  {{ ansible_facts.distribution_release == 'noble' or (ansible_facts.distribution == 'Debian' and ansible_facts.distribution_major_version | int >= 13) }}
 # Path to template OVMF efi variable store. A copy will be created
 # for each VM created.
-libvirt_vm_ovmf_efi_variable_store_path: "/usr/share/OVMF/{{ 'OVMF_VARS_4M.fd' if ansible_facts.distribution_release == 'noble' else 'OVMF_VARS.fd' }}"
+libvirt_vm_ovmf_efi_variable_store_path: "/usr/share/OVMF/{{ 'OVMF_VARS_4M.fd' if __libvirt_vm_ovmf_debian_4m_efivars else 'OVMF_VARS.fd' }}"
 
 # Format of the template OVMF efi variable store.
 libvirt_vm_ovmf_efi_variable_store_format: raw
 
 # Path to OVMF efi firmware
-libvirt_vm_ovmf_efi_firmware_path: "/usr/share/OVMF/{{ 'OVMF_CODE_4M.fd' if ansible_facts.distribution_release == 'noble' else 'OVMF_CODE.fd' }}"
+libvirt_vm_ovmf_efi_firmware_path: "/usr/share/OVMF/{{ 'OVMF_CODE_4M.fd' if __libvirt_vm_ovmf_debian_4m_efivars else 'OVMF_CODE.fd' }}"


### PR DESCRIPTION
Debian 13 also removed `OVMF_VARS.fd` and `OVMF_CODE.fd` like Ubuntu Noble.